### PR TITLE
Fixed depricated /e

### DIFF
--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -371,7 +371,9 @@ class sfWebResponse extends sfResponse
    */
   protected function normalizeHeaderName($name)
   {
-    return preg_replace('/\-(.)/e', "'-'.strtoupper('\\1')", strtr(ucfirst(strtolower($name)), '_', '-'));
+    return preg_replace_callback('/\-(.)/', function($m) {
+      return '-'.strtoupper($m[1]);
+    }, strtr(ucfirst(strtolower($name)) , '_', '-'));
   }
 
   /**


### PR DESCRIPTION
http://php.net/preg_replace : "An E_DEPRECATED level error is emitted when passing in the "\e" modifier."

Fixed expression to use preg_replace_callback. Once accepted, I will create pull requests for the other branches.
