### PR TITLE
Two small fixes in the sfPropelPlugin for newer PHP versions

### DIFF
--- a/lib/plugins/sfPropelPlugin/lib/vendor/phing/system/io/UnixFileSystem.php
+++ b/lib/plugins/sfPropelPlugin/lib/vendor/phing/system/io/UnixFileSystem.php
@@ -191,7 +191,7 @@ class UnixFileSystem extends FileSystem {
     /* -- most of the following is mapped to the php natives wrapped by FileSystem */    
 
     /* -- Attribute accessors -- */
-    function getBooleanAttributes(&$f) {
+    function getBooleanAttributes($f) {
         //$rv = getBooleanAttributes0($f);
         $name = $f->getName();
         $hidden = (strlen($name) > 0) && ($name{0} == '.');

--- a/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/platform/MysqlPlatform.php
+++ b/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/platform/MysqlPlatform.php
@@ -94,8 +94,8 @@ class MysqlPlatform extends DefaultPlatform {
 	 */
 	public function disconnectedEscapeText($text)
 	{
-		if (function_exists('mysql_escape_string')) {
-			return mysql_escape_string($text);
+		if (function_exists('mysql_real_escape_string')) {
+			return mysql_real_escape_string($text);
 		} else {
 			return addslashes($text);
 		}


### PR DESCRIPTION
I'v patched the sfPropelPlugin for newer versions of PHP that have deprecated mysql_escape_string
