### PR TITLE
Added feature to specify the phpVisiblity in database generation

### DIFF
--- a/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/builder/om/php5/PHP5BasicObjectBuilder.php
+++ b/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/builder/om/php5/PHP5BasicObjectBuilder.php
@@ -324,6 +324,7 @@ abstract class ".$this->getClassname()." extends ".ClassTools::classname($this->
 	protected function addTemporalAccessor(&$script, $col)
 	{
 		$cfc=$col->getPhpName();
+		$vis=$col->getPhpVisiblility();
 		$clo=strtolower($col->getName());
 
 		// these default values are based on the Creole defaults
@@ -349,7 +350,7 @@ abstract class ".$this->getClassname()." extends ".ClassTools::classname($this->
 	 * @return     mixed Formatted date/time value as string or integer unix timestamp (if format is NULL).
 	 * @throws     PropelException - if unable to convert the date/time to timestamp.
 	 */
-	public function get$cfc(\$format = ".var_export($defaultfmt, true)."";
+	$vis function get$cfc(\$format = ".var_export($defaultfmt, true)."";
 		if ($col->isLazyLoad()) $script .= ", \$con = null";
 		$script .= ")
 	{
@@ -393,6 +394,7 @@ abstract class ".$this->getClassname()." extends ".ClassTools::classname($this->
 	protected function addGenericAccessor(&$script, $col)
 	{
 		$cfc=$col->getPhpName();
+		$vis=$col->getPhpVisiblility();
 		$clo=strtolower($col->getName());
 
 		$script .= "
@@ -401,7 +403,7 @@ abstract class ".$this->getClassname()." extends ".ClassTools::classname($this->
 	 * ".$col->getDescription()."
 	 * @return     ".$col->getPhpNative()."
 	 */
-	public function get$cfc(";
+	$vis function get$cfc(";
 		if ($col->isLazyLoad()) $script .= "\$con = null";
 		$script .= ")
 	{
@@ -491,6 +493,7 @@ abstract class ".$this->getClassname()." extends ".ClassTools::classname($this->
 	protected function addMutatorOpen(&$script, Column $col)
 	{
 		$cfc=$col->getPhpName();
+		$vis=$col->getPhpVisiblility();
 		$clo=strtolower($col->getName());
 
 		$script .= "
@@ -500,7 +503,7 @@ abstract class ".$this->getClassname()." extends ".ClassTools::classname($this->
 	 * @param      ".$col->getPhpNative()." \$v new value
 	 * @return     void
 	 */
-	public function set$cfc(\$v)
+	$vis function set$cfc(\$v)
 	{
 ";
 		if ($col->isLazyLoad()) {

--- a/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/database/model/Column.php
+++ b/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/database/model/Column.php
@@ -45,6 +45,7 @@ class Column extends XMLElement {
 	private $description;
 	private $phpName = null;
 	private $phpNamingMethod;
+	private $phpVisiblity = 'public';
 	private $isNotNull = false;
 	private $size;
 
@@ -149,6 +150,11 @@ class Column extends XMLElement {
 			$this->phpName = $this->getAttribute("phpName");
 			$this->phpType = $this->getAttribute("phpType");
 			$this->peerName = $this->getAttribute("peerName");
+			$this->phpVisiblity = $this->getAttribute('phpVisibility');
+
+			if (!in_array($this->phpVisiblity, ['public', 'protected', 'private'])) {
+				$this->phpVisiblity = 'public';
+			}
 
 			if (empty($this->phpType)) {
 				$this->phpType = null;
@@ -917,5 +923,16 @@ class Column extends XMLElement {
 		$sb .= $this->getNotNullString() . " ";
 		$sb .= $this->getAutoIncrementString();
 		return trim($sb);
+	}
+
+	/**
+	 * Return the desired visibility for the column. This can be: 'public',
+	 * 'protected' or 'private'.
+	 *
+	 * @return string
+	 */
+	public function getPhpVisiblility()
+	{
+		return $this->phpVisiblity;
 	}
 }


### PR DESCRIPTION
With this pull it will become possible to specify the visibility of the generated methods for the propel database schema.

This is useful when you are trying to migrate your model to another version of propel or even a different ORM such as doctrine where those methods might not be fully compatible to make it forwards compatible.
