### PR TITLE
PHP7 consistent ordering for splitHttpAcceptHeader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: php
+php:
+  - 7.0
+  - 5.6
+  - hhvm
+
+before_script:
+    - composer install --dev
+
+script:
+    - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,48 @@
 {
-    "name": "symfony/symfony1",
+    "name":        "symfony/symfony1",
     "description": "Symfony is a complete framework designed to optimize the development of web applications by way of several key features. For starters, it separates a web application's business rules, server logic, and presentation views. It contains numerous tools and classes aimed at shortening the development time of a complex web application. Additionally, it automates common tasks so that the developer can focus entirely on the specifics of an application. The end result of these advantages means there is no need to reinvent the wheel every time a new web application is built!",
-    "authors": [
+     "authors": [
 	        {
             "name": "Fabien Potencier",
             "email": "fabien@symfony.com"
         }
     ],
-    "license": "MIT"
+   "license":     "MIT",
+    "require-dev": {
+        "phpunit/phpunit": "^5.5"
+    },
+    "autoload-dev": {
+        "classmap": [
+            "lib/action",
+            "lib/addon",
+            "lib/autoload",
+            "lib/cache",
+            "lib/command",
+            "lib/config",
+            "lib/controller",
+            "lib/database",
+            "lib/debug",
+            "lib/event",
+            "lib/exception",
+            "lib/filter",
+            "lib/form",
+            "lib/generator",
+            "lib/helper",
+            "lib/i18n",
+            "lib/log",
+            "lib/plugin",
+            "lib/request",
+            "lib/response",
+            "lib/routing",
+            "lib/storage",
+            "lib/task",
+            "lib/user",
+            "lib/util",
+            "lib/validator",
+            "lib/vendor",
+            "lib/view",
+            "lib/widget",
+            "lib/yaml"
+        ]
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors                 = "true"
+         bootstrap              = "vendor/autoload.php"
+         backupGlobals          = "false"
+         backupStaticAttributes = "false">
+
+    <testsuites>
+        <testsuite name="Symfony1 test" >
+            <directory>./test/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./lib</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/test/lib/request/sfWebRequestTest.php
+++ b/test/lib/request/sfWebRequestTest.php
@@ -1,0 +1,74 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once(__DIR__ . '/../../../lib/request/sfWebRequest.class.php');
+
+class sfWebRequestTest extends TestCase
+{
+
+    /**
+     * @var sfWebRequest
+     */
+    private $request;
+
+    protected function setUp()
+    {
+        $event_dispatcher = new sfEventDispatcher();
+        $this->request = new sfWebRequest($event_dispatcher);
+    }
+
+    /**
+     * @dataProvider splitHttpAcceptHeaderProvider
+     * @covers sfWebRequest::splitHttpAcceptHeader
+     */
+    public function testSplitHttpAcceptHeader($header, $expected)
+    {
+        self::assertSame($expected, $this->request->splitHttpAcceptHeader($header));
+    }
+
+    public function splitHttpAcceptHeaderProvider()
+    {
+        return [
+            [
+                "text/javascript, text/html, application/xml, text/xml, */*",
+                [
+                    ' */*',
+                    ' text/xml',
+                    ' application/xml',
+                    ' text/html',
+                    'text/javascript',
+                ]
+            ],
+            [
+                "text/javascript, text/html;q=2.9, application/xml, text/xml, */*",
+                [
+                    'text/html',
+                    ' */*',
+                    ' text/xml',
+                    ' application/xml',
+                    'text/javascript',
+                ]
+            ],
+            [
+                "text/javascript;q=1.0, text/html;q=2.9, application/xml, text/xml, */*",
+                [
+                    'text/html',
+                    ' */*',
+                    ' text/xml',
+                    ' application/xml',
+                    'text/javascript',
+                ]
+            ],
+            [
+                "text/javascript;q=1.0, text/html;q=1.0, application/xml, text/xml, */*",
+                [
+                    ' */*',
+                    ' text/xml',
+                    ' application/xml',
+                    'text/html',
+                    'text/javascript',
+                ]
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
In PHP7 sorting order is changed, splitHttpAcceptHeader was
relying on unspecified behaviour of arsort(). Sorting order
is now made explicit.
