### PR TITLE
Add php7.1, remove hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 php:
+  - 7.1
   - 7.0
   - 5.6
-  - hhvm
 
 before_script:
     - composer install --dev


### PR DESCRIPTION
HHVM build errors about

```
The command "sudo apt-get install -y hhvm" failed and exited with 100 during .
```

https://travis-ci.org/hostnet/symfony1/jobs/231082063