### PR TITLE
Fix counting on null in sfValidatorConfigHandler

### DIFF
--- a/lib/plugins/sfCompat10Plugin/lib/config/sfValidatorConfigHandler.class.php
+++ b/lib/plugins/sfCompat10Plugin/lib/config/sfValidatorConfigHandler.class.php
@@ -104,7 +104,7 @@ class sfValidatorConfigHandler extends sfYamlConfigHandler
 
     $this->generateRegistration('GET', $data, $methods, $names, $validators);
 
-    if (count($fillin))
+    if ($fillin !== null && count($fillin))
     {
       $data[] = sprintf("  \$this->context->getRequest()->setAttribute('symfony.fillin', %s);", $fillin);
     }
@@ -117,7 +117,7 @@ class sfValidatorConfigHandler extends sfYamlConfigHandler
 
     $this->generateRegistration('POST', $data, $methods, $names, $validators);
 
-    if (count($fillin))
+    if ($fillin !== null && count($fillin))
     {
       $data[] = sprintf("  \$this->context->getRequest()->setAttribute('symfony.fillin', %s);", $fillin);
     }


### PR DESCRIPTION
Fixes "_Warning: count(): Parameter must be an array or an object that implements Countable_"