### PR TITLE
Fixed php7.2 deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+  - 7.2
   - 7.1
   - 7.0
   - 5.6

--- a/lib/yaml/sfYamlInline.class.php
+++ b/lib/yaml/sfYamlInline.class.php
@@ -99,11 +99,14 @@ class sfYamlInline
   static protected function dumpArray($value)
   {
     // array
+    $fn = function ($v, $w) {
+        return ((int) $v) + ((int) $w);
+    };
     $keys = array_keys($value);
     if (
       (1 == count($keys) && '0' == $keys[0])
       ||
-      (count($keys) > 1 && array_reduce($keys, create_function('$v,$w', 'return ((int) $v) + ((int) $w);'), 0) == count($keys) * (count($keys) - 1) / 2))
+      (count($keys) > 1 && array_reduce($keys, $fn, 0) == count($keys) * (count($keys) - 1) / 2))
     {
       $output = array();
       foreach ($value as $val)

--- a/test/lib/yaml/sfYamlInlineTest.php
+++ b/test/lib/yaml/sfYamlInlineTest.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types = 1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once(__DIR__ . '/../../../lib/yaml/sfYamlInline.class.php');
+
+class sfYamlInlineTest extends TestCase
+{
+    /**
+     * @dataProvider dumpProvider
+     */
+    public function testDump($value, $expected)
+    {
+        self::assertSame($expected, sfYamlInline::dump($value));
+    }
+
+    public function dumpProvider()
+    {
+        return [
+            [null, 'null'],
+            ['string', 'string'],
+            [true, 'true'],
+            [false, 'false'],
+            [6, 6],
+            ["asdf\nasdf", '"asdf\nasdf"'],
+            ['', "''"],
+            ['1234', "'1234'"],
+            ['true', "'true'"],
+            ['false', "'false'"],
+            [['a', 'b'], '[a, b]'],
+            [['a' => 'b'], '{ a: b }']
+        ];
+    }
+}


### PR DESCRIPTION
`create_function` has been DEPRECATED as of PHP 7.2.0. Relying on this function is highly discouraged.

Rewrote it to an anonymous function, which is available since php 5.4.