### PR TITLE
sfPatternRouting 7.2 compat

### DIFF
--- a/lib/routing/sfPatternRouting.class.php
+++ b/lib/routing/sfPatternRouting.class.php
@@ -58,9 +58,16 @@ class sfPatternRouting extends sfRouting
       $options['variable_regex'] = '[\w\d_]+';
     }
 
-    $options['variable_prefix_regex']    = '(?:'.implode('|', array_map(create_function('$a', 'return preg_quote($a, \'#\');'), $options['variable_prefixes'])).')';
-    $options['segment_separators_regex'] = '(?:'.implode('|', array_map(create_function('$a', 'return preg_quote($a, \'#\');'), $options['segment_separators'])).')';
-    $options['variable_content_regex']   = '[^'.implode('', array_map(create_function('$a', 'return str_replace(\'-\', \'\-\', preg_quote($a, \'#\'));'), $options['segment_separators'])).']+';
+    $quote   = function ($a) {
+        return preg_quote($a, '#');
+    };
+    $replace = function ($a) {
+        return str_replace('-', '\-', preg_quote($a, '#'));
+    };
+
+    $options['variable_prefix_regex']    = '(?:'.implode('|', array_map($quote, $options['variable_prefixes'])).')';
+    $options['segment_separators_regex'] = '(?:'.implode('|', array_map($quote, $options['segment_separators'])).')';
+    $options['variable_content_regex']   = '[^'.implode('', array_map($replace, $options['segment_separators'])).']+';
 
     if (!isset($options['load_configuration']))
     {

--- a/test/lib/routing/sfPatternRoutingTest.php
+++ b/test/lib/routing/sfPatternRoutingTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types = 1);
+
+use PHPUnit\Framework\TestCase;
+
+class sfPatternRoutingTest extends TestCase
+{
+    /**
+     * @dataProvider findRouteProvider
+     */
+    public function testFindRoute($url, $expected_name, array $expected_params)
+    {
+        $dispatcher = new sfEventDispatcher();
+        $router = new sfPatternRouting($dispatcher);
+        $router->connect('hello_world', '/hello/world');
+        $router->connect('hello_name', '/hello/:name');
+        $router->connect('default', '/:module/:action/*');
+
+        $result = $router->findRoute($url);
+        self::assertSame($expected_name, $result['name']);
+        self::assertSame($expected_params, $result['parameters']);
+    }
+
+    public function findRouteProvider()
+    {
+        return [
+            ['/hello/world', 'hello_world', ['module' => 'default', 'action' => 'index']],
+            ['/hello/henk', 'hello_name', ['module' => 'default', 'action' => 'index', 'name' => 'henk']],
+            ['/a/b', 'default', ['module' => 'a', 'action' => 'b']],
+            ['/a/b/c/d', 'default', ['c' => 'd', 'module' => 'a', 'action' => 'b']],
+        ];
+    }
+}


### PR DESCRIPTION
`create_function` has been DEPRECATED as of PHP 7.2.0. Relying on this function is highly discouraged.

Used anonymous function instead.