### PR TITLE
Fix error count(): Parameter must implement Countable

### DIFF
--- a/lib/plugins/sfCompat10Plugin/lib/config/sfValidatorConfigHandler.class.php
+++ b/lib/plugins/sfCompat10Plugin/lib/config/sfValidatorConfigHandler.class.php
@@ -104,7 +104,7 @@ class sfValidatorConfigHandler extends sfYamlConfigHandler
 
     $this->generateRegistration('GET', $data, $methods, $names, $validators);
 
-    if ($fillin !== null && count($fillin))
+    if ($fillin !== null && strlen($fillin))
     {
       $data[] = sprintf("  \$this->context->getRequest()->setAttribute('symfony.fillin', %s);", $fillin);
     }
@@ -117,7 +117,7 @@ class sfValidatorConfigHandler extends sfYamlConfigHandler
 
     $this->generateRegistration('POST', $data, $methods, $names, $validators);
 
-    if ($fillin !== null && count($fillin))
+    if ($fillin !== null && strlen($fillin))
     {
       $data[] = sprintf("  \$this->context->getRequest()->setAttribute('symfony.fillin', %s);", $fillin);
     }

--- a/test/lib/plugins/sfCompat10Plugin/lib/config/sfValidatorConfigHandlerTest.php
+++ b/test/lib/plugins/sfCompat10Plugin/lib/config/sfValidatorConfigHandlerTest.php
@@ -1,0 +1,30 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once(__DIR__ . '/../../../../../../lib/plugins/sfCompat10Plugin/lib/config/sfValidatorConfigHandler.class.php');
+
+/**
+ * @covers sfValidatorConfigHandler
+ */
+class sfValidatorConfigHandlerTest extends TestCase
+{
+    public function testExecute()
+    {
+        $handler = new sfValidatorConfigHandler();
+        $handler->initialize();
+
+        $dir = __DIR__ . '/../../../../../../lib/plugins/sfCompat10Plugin/test/unit/config/fixtures/sfValidatorConfigHandler/';
+
+        // standard format
+        $files         = array($dir.'standard_format.yml');
+        $standard_data = $handler->execute($files);
+        $standard_data = preg_replace('#date\: \d+/\d+/\d+ \d+\:\d+\:\d+#', '', $standard_data);
+
+        // alternate format
+        $files          = array($dir.'alternate_format.yml');
+        $alternate_data = $handler->execute($files);
+        $alternate_data = preg_replace('#date\: \d+/\d+/\d+ \d+\:\d+\:\d+#', '', $alternate_data);
+
+        self::assertSame($standard_data, $alternate_data, 'standard and alternate format of validate.yml files produce the same output');
+    }
+}


### PR DESCRIPTION
Using the `sfValidatorConfigHandler` on php 7.2 results in
```
count(): Parameter must be an array or an object that implements Countable
```

This PR fixes that. In the BC layer for sf1.0. Cheers!